### PR TITLE
added chrome capability

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -1,3 +1,6 @@
+let browser = (typeof chrome !== 'undefined') ? chrome : (typeof browser !== 'undefined') ? browser : null;
+
+
 function getPageContent() {
     console.log("getPageContent called");
     return document.body.innerText;

--- a/manifest_ch.json
+++ b/manifest_ch.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SpaceLLama",
   "version": "1.21",
-  "description": "Summarize web pages using Ollama.",
+  "description": "Summarize web pages using Ollama. Supports custom models, token limits, system prompts, chunking, and more. See https://github.com/tcsenpai/spacellama for more information.",
   "permissions": ["activeTab", "storage", "tabs", "scripting"],
   "action": {
     "default_title": "SpaceLLama",

--- a/manifest_ch.json
+++ b/manifest_ch.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "name": "SpaceLLama",
+  "version": "1.21",
+  "description": "Summarize web pages using Ollama.",
+  "permissions": ["activeTab", "storage", "tabs", "scripting"],
+  "action": {
+    "default_title": "SpaceLLama",
+    "default_icon": "icon.png"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content_scripts/content.js"]
+    }
+  ],
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["sidebar/sidebar.html", "sidebar/sidebar.js", "sidebar/sidebar.css", "sidebar/marked.min.js", "model_tokens.json"],
+      "matches": ["http://*/*", "https://*/*"]
+    }
+  ]
+}

--- a/options/options.js
+++ b/options/options.js
@@ -1,3 +1,5 @@
+let browser = (typeof chrome !== 'undefined') ? chrome : (typeof browser !== 'undefined') ? browser : null;
+ 
 async function validateEndpoint(endpoint) {
   try {
     const response = await fetch(`${endpoint}/api/tags`);
@@ -14,6 +16,31 @@ function updateEndpointStatus(isValid) {
   statusElement.title = isValid ? "Endpoint is valid" : "Endpoint is invalid";
 }
 
+async function updateTokenLimit() {
+  try {
+    const modelTokens = await loadModelTokens();
+    const model = document.getElementById("model").value;
+    const tokenLimitInput = document.getElementById("token-limit");
+
+    if (model in modelTokens) {
+      tokenLimitInput.value = modelTokens[model];
+    } else {
+      tokenLimitInput.value = 4000; // Default value, modified from 4096 to meet even requirement
+    }
+  } catch (error) {
+    console.error("Error updating token limit:", error.message || error);
+  }
+}
+
+async function loadModelTokens() {
+  try {
+    const response = await fetch(browser.runtime.getURL('model_tokens.json'));
+    return await response.json();
+  } catch (error) {
+    console.error("Error loading model tokens:", error.message || error);
+  }
+}
+
 async function saveOptions(e) {
   e.preventDefault();
   const endpoint = document.getElementById("endpoint").value;
@@ -24,71 +51,58 @@ async function saveOptions(e) {
   // Ensure the endpoint doesn't end with /api/generate
   const cleanEndpoint = endpoint.replace(/\/api\/generate\/?$/, "");
   status.textContent = "Validating endpoint...";
-  const isValid = await validateEndpoint(cleanEndpoint);
-  updateEndpointStatus(isValid);
-  if (isValid) {
-    browser.storage.local
-      .set({
+  try {
+    const isValid = await validateEndpoint(cleanEndpoint);
+    updateEndpointStatus(isValid);
+    if (isValid) {
+      await browser.storage.local.set({
         ollamaEndpoint: cleanEndpoint,
         ollamaModel: model,
         systemPrompt: systemPrompt,
         tokenLimit: parseInt(tokenLimit),
-      })
-      .then(() => {
-        status.textContent = "Options saved and endpoint validated.";
-        setTimeout(() => {
-          status.textContent = "";
-        }, 2000);
       });
-  } else {
-    status.textContent =
+      status.textContent = "Options saved and endpoint validated.";
+      setTimeout(() => {
+        status.textContent = "";
+      }, 2000);
+    } else {
+      status.textContent =
       "Invalid endpoint. Please check the URL and try again.";
+    }
+  } catch (error) {
+    console.error("Error saving options:", error.message || error);
+    status.textContent = "Error saving options.";
   }
 }
 
-async function restoreOptions() {
-  const result = await browser.storage.local.get([
-    "ollamaEndpoint",
-    "ollamaModel",
-    "systemPrompt",
-    "tokenLimit",
-  ]);
-  const endpoint = result.ollamaEndpoint || "http://localhost:11434";
-  const defaultSystemPrompt = "You are a helpful AI assistant. Summarize the given text concisely.";
-  document.getElementById("endpoint").value = endpoint;
-  document.getElementById("model").value = result.ollamaModel || "llama2";
-  document.getElementById("system-prompt").value = result.systemPrompt || defaultSystemPrompt;
-  
-  await updateTokenLimit();
-  
-  const isValid = await validateEndpoint(endpoint);
-  updateEndpointStatus(isValid);
+function restoreOptions() {
+  browser.storage.local.get({
+    ollamaEndpoint: "http://localhost:11434",
+    ollamaModel: "llama2",
+    systemPrompt: "You are a helpful AI assistant. Summarize the given text concisely.",
+    tokenLimit: 4096
+  }, function(result) {
+    document.getElementById("endpoint").value = result.ollamaEndpoint || "http://localhost:11434";
+    document.getElementById("model").value = result.ollamaModel || "llama2";
+    document.getElementById("system-prompt").value = result.systemPrompt || "You are a helpful AI assistant. Summarize the given text concisely.";
+
+    // Call to updateTokenLimit remains async
+    updateTokenLimit().then(() => {
+      validateEndpoint(result.ollamaEndpoint).then(isValid => {
+        updateEndpointStatus(isValid);
+      });
+    });
+  });
 }
+
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document
   .getElementById("settings-form")
   .addEventListener("submit", saveOptions);
 document.getElementById("endpoint").addEventListener("blur", async (e) => {
-  const isValid = await validateEndpoint(e.target.value);
-  updateEndpointStatus(isValid);
-});
-
-async function loadModelTokens() {
-  const response = await fetch(browser.runtime.getURL('model_tokens.json'));
-  return await response.json();
-}
-
-async function updateTokenLimit() {
-  const modelTokens = await loadModelTokens();
-  const model = document.getElementById("model").value;
-  const tokenLimitInput = document.getElementById("token-limit");
-  
-  if (model in modelTokens) {
-    tokenLimitInput.value = modelTokens[model];
-  } else {
-    tokenLimitInput.value = 4096; // Default value
-  }
-}
+const isValid = await validateEndpoint(e.target.value);
+updateEndpointStatus(isValid);
 
 document.getElementById("model").addEventListener("change", updateTokenLimit);
+});

--- a/sidebar/sidebar.css
+++ b/sidebar/sidebar.css
@@ -47,26 +47,33 @@ h1 {
 }
 
 .summary-container {
-    margin-top: 20px;
-    padding: 15px;
+    margin-top: 10px;
+    padding: 10px;
     background-color: white;
     border-radius: 5px;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 #summary h1, #summary h2, #summary h3 {
-    margin-top: 15px;
-    margin-bottom: 10px;
+    margin-top: 0px;
+    margin-bottom: 0px;
     color: #2c3e50;
 }
 
 #summary p {
+    margin-top: 10px;
     margin-bottom: 10px;
     line-height: 1.6;
 }
 
 #summary ul, #summary ol {
     padding-left: 20px;
+    margin-bottom: 10px;
+    margin-top: 10px;
+    
+}
+
+#summary li {
     margin-bottom: 10px;
 }
 
@@ -90,7 +97,7 @@ h1 {
 }
 
 .form-group {
-    margin-top: 20px;
+    margin-top: 10px;
 }
 
 label {
@@ -120,6 +127,6 @@ textarea {
 }
 
 #summary {
-  white-space: pre-wrap;
+  /* white-space: pre-wrap; */
   word-wrap: break-word;
 }

--- a/sidebar/sidebar.js
+++ b/sidebar/sidebar.js
@@ -1,3 +1,6 @@
+let isFirefox = typeof InstallTrigger !== 'undefined';  // Firefox has `InstallTrigger`
+let browser = isFirefox ? window.browser : chrome; 
+
 document.addEventListener("DOMContentLoaded", () => {
   const summarizeButton = document.getElementById("summarize");
   const summaryDiv = document.getElementById("summary");
@@ -8,12 +11,15 @@ document.addEventListener("DOMContentLoaded", () => {
   tokenCountDiv.style.fontStyle = "italic";
 
   summarizeButton.parentNode.insertBefore(tokenCountDiv, summarizeButton.nextSibling);
+  // Correctly define systemPromptTextarea
+  const systemPromptTextarea = document.getElementById("system-prompt");
 
   summarizeButton.addEventListener("click", () => {
     summaryDiv.innerHTML = "<p>Summarizing...</p>";
     tokenCountDiv.textContent = "";
     summarizeButton.disabled = true;
 
+    // Get the current tab content
     browser.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       browser.tabs.sendMessage(
         tabs[0].id,
@@ -28,6 +34,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
           if (response && response.content) {
             const systemPrompt = systemPromptTextarea.value;
+            // Send message to background script for summarization
             browser.runtime.sendMessage(
               { action: "summarize", content: response.content, systemPrompt: systemPrompt },
               (response) => {
@@ -50,7 +57,6 @@ document.addEventListener("DOMContentLoaded", () => {
                       </div>
                     `;
                   }
-
                   let summaryText;
                   if (typeof response.summary === 'string') {
                     summaryText = response.summary;
@@ -59,7 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     summaryText = Object.entries(response.summary)
                       .map(([key, value]) => `## ${key}\n\n${value}`)
                       .join('\n\n');
-                  } else {
+                    } else {
                     summaryText = JSON.stringify(response.summary);
                   }
 
@@ -98,7 +104,6 @@ document.addEventListener("DOMContentLoaded", () => {
     summarizeButton.disabled = false;
   }
 });
-
 const systemPromptTextarea = document.getElementById("system-prompt");
 const savePromptButton = document.getElementById("save-prompt");
 


### PR DESCRIPTION
in each of the js files, background.js, sidebar.js, options,js, and content.js, I added some logic to support chrome. where possible I left the code untouched. I did a diff compare to align my sections with yours.

one assumption I made is that we want this to work with firefox and chrome, so in background.js and sidebar.js there is a check for firefox at the very top of the file. If you want this to run on alternate browsers this section will need to be modified. I believe the check logic in options.js and content.js will work with any firefox like browser and chrome.

I slightly modified the sidebar.css to compress the total vertical screen space, this is just cosmetic. 

Firefox remains in manifest v2, so the manifest.json should be the same or modified very very slightly, for Chrome I set it up for manifest v3.

Both Firefox and Chrome want manifest.json to be named exactly that, but each requires a different manifest. In this pull request the Firefox one is manifest.json, and the Chrome one is currently named manifest_ch.json, which of course will need to be renamed to import into Chrome.

My thought is that the code can be maintained as is, and the user simply needs to have the right manifest.

Last, but not least. I have tested this with my Ollama instance on both Firefox and Chrome (current patch levels as of 10/15/2024) on Windows 11, and both work exactly as currently desired.